### PR TITLE
parses bot generator lists with lines like "Sogou\ web\ spider"

### DIFF
--- a/botblocker.go
+++ b/botblocker.go
@@ -129,7 +129,7 @@ func readUserAgents(userAgentReader io.ReadCloser) ([]string, error) {
 	defer userAgentReader.Close()
 	scanner := bufio.NewScanner(userAgentReader)
 	for scanner.Scan() {
-		agent := strings.ToLower(strings.TrimSpace(scanner.Text()))
+		agent := strings.ToLower(strings.TrimSpace(strings.ReplaceAll(scanner.Text(), "\\", "")))
 		userAgents = append(userAgents, agent)
 	}
 

--- a/botblocker_test.go
+++ b/botblocker_test.go
@@ -1,8 +1,10 @@
 package traefik_simplified_bad_bot_blocker
 
 import (
+	"io"
 	"net/netip"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +72,16 @@ func TestReadUserAgents(t *testing.T) {
 	userAgents, err := readUserAgents(f)
 	if !equalStrings(userAgents, expected) || err != nil {
 		t.Fatalf("readUserAgents(f) = %v, %e; want %v, <nil>", userAgents, err, expected)
+	}
+}
+
+func TestReadUserAgentsStripsBackslashes(t *testing.T) {
+	input := io.NopCloser(strings.NewReader("Sogou\\ web\\ spider\n"))
+
+	expected := []string{"sogou web spider"}
+	userAgents, err := readUserAgents(input)
+	if !equalStrings(userAgents, expected) || err != nil {
+		t.Fatalf("readUserAgents(input) = %v, %e; want %v, <nil>", userAgents, err, expected)
 	}
 }
 


### PR DESCRIPTION
I prefer your branch to the DiscoverGarden one, because you do O(1) map lookup versus O(logn) array walk.

Can I make this contribution:
  the [nginx bot generator list](https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/refs/heads/master/_generator_lists/bad-user-agents.list) has some entries like "Sogou\ web\ spider".
  these are not parsed correctly by this bot-blocker.
  
  The actual incoming GET has a User-Agent like:  "Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)"
  
  By adding a .ReplaceAll("//", ""), the bot-blocker correctly blocks such user agents.  Now, this app parses it as "sogou web spider", which correctly matches the block criteria.

There is a test added as well.

Garrett Armstrong